### PR TITLE
Fix invenio.py

### DIFF
--- a/data_collections/invenio.py
+++ b/data_collections/invenio.py
@@ -236,12 +236,12 @@ class _Files(_SubCommandHandler):
 
     @property
     def datastore_url(self) -> str:
-        """Get URL for new API file bucket.
+        """Get URL for new API file datastore.
 
         Returns
         -------
         str
-            File bucket to ``put`` files.
+            File datastore to ``put`` files.
         """
         return self.parent.datastore_url
 
@@ -368,12 +368,12 @@ class _Record(_SubCommandHandler):
 
     @cached_property
     def datastore_url(self):
-        """Get URL for new API file bucket.
+        """Get URL for new API file datastore.
 
         Returns
         -------
         str
-            File bucket to ``put`` files.
+            File datastore to ``put`` files.
         """
         return self.get().json()["links"]["self"]
 


### PR DESCRIPTION
General improvements to `invenio.py` and rework to deal with records rather than depositions (new-style API).

- Functions now return the json rather than the bare response.
- Add api tag (Fixes #1) 
- Maybe #2 
- Migrate to records API as primary with depositions as secondary
- Pass down `api_url` which describes URL up to this point to construct URL consistently down the chain.
